### PR TITLE
Update dynamic image builder CI pipelines to use ubuntu 24 as a base image

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_master:
     name: Build branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
       - name: Checkout project
         uses: actions/checkout@v3

--- a/.github/workflows/build_master.yaml
+++ b/.github/workflows/build_master.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_master:
     name: Build master
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
       - name: Checkout project
         uses: actions/checkout@v3

--- a/.github/workflows/release_chart.yaml
+++ b/.github/workflows/release_chart.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Release Chart
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 jobs:
   run_tests:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
       - uses: actions/checkout@v3
       - name: Cache python

--- a/.shopify-build/clickhouse-operator-shopify.yml
+++ b/.shopify-build/clickhouse-operator-shopify.yml
@@ -1,7 +1,7 @@
 containers:
   default:
     build:
-      from: ubuntu-latest
+      from: ubuntu-24
       type: ci
   clickhouse-operator:
     environment: production


### PR DESCRIPTION
What: Update dynamic image builder CI pipelines to use ubuntu 24 as a base image
Why: Upgrading all image builder pipelines to use ubuntu-24 as the base image helps ensure that the images we deploy to production have the most up-to-date libraries and security patches.

[ServicesDB Link](https://services.shopify.io/action-items/instances/69238)